### PR TITLE
Simplify widgets creation

### DIFF
--- a/samples/form/main.kt
+++ b/samples/form/main.kt
@@ -10,17 +10,20 @@ fun main(args: Array<String>) = application {
         hasMenubar = false)
     window.margined = true
 
-    val box = VerticalBox().apply { padded = true }
+    val box = VerticalBox { padded = true }
 
     val username = Entry()
     val password = PasswordEntry()
-    val form = Form().apply { padded = true }
-    form.append("Username", username)
-    form.append("Password", password)
+    val form = Form {
+        padded = true
+        append("Username", username)
+        append("Password", password)
+    }
 
-    val button = Button(text = "Login")
-    button.action {
-        uiMsgBox(window, title = "Info", description = "${username.text}:${password.text}")
+    val button = Button(text = "Login") {
+        action {
+            uiMsgBox(window, title = "Info", description = "${username.text}:${password.text}")
+        }
     }
 
     box.append(form)

--- a/samples/hello/hello2.kt
+++ b/samples/hello/hello2.kt
@@ -6,15 +6,15 @@ fun main(args: Array<String>) = application {
         title = "Hello",
         width = 320,
         height = 240,
-        hasMenubar = false).apply {
+        hasMenubar = false) {
         margined = true
 
-        val box = VerticalBox().apply {
+        val box = VerticalBox {
             padded = true
-            val scroll = MultilineEntry().apply {
+            val scroll = MultilineEntry {
                 readOnly = true
             }
-            val button = Button("libui говорит: click me!").apply {
+            val button = Button("libui говорит: click me!") {
                 action {
                     scroll.append("Hello, World!  Ciao, mondo!\n" +
                                   "Привет, мир!  你好，世界！\n\n")

--- a/src/main/kotlin/widgets.kt
+++ b/src/main/kotlin/widgets.kt
@@ -41,8 +41,8 @@ import platform.posix.tm
 typealias Window = CPointer<uiWindow>
 
 /** Create a new Window. */
-fun Window(title: String, width: Int, height: Int, hasMenubar: Boolean = true) : Window
-    = uiNewWindow(title, width, height, if (hasMenubar) 1 else 0) ?: throw Error()
+fun Window(title: String, width: Int, height: Int, hasMenubar: Boolean = true, block: Window.() -> Unit = {}) : Window
+    = uiNewWindow(title, width, height, if (hasMenubar) 1 else 0)?.apply(block) ?: throw Error()
 
 /** Destroy and free the Window. */
 fun Window.destroy() = uiControlDestroy(reinterpret())
@@ -162,7 +162,7 @@ internal fun _onClose(window: Window?, ref: COpaquePointer?): Int {
 typealias Form = CPointer<uiForm>
 
 /** Create a new Form. */
-fun Form() : Form = uiNewForm() ?: throw Error()
+fun Form(block: Form.() -> Unit = {}) : Form = uiNewForm()?.apply(block) ?: throw Error()
 
 /** Destroy and free the Form. */
 fun Form.destroy() = uiControlDestroy(reinterpret())
@@ -270,10 +270,10 @@ var Grid.padded: Boolean
 typealias Box = CPointer<uiBox>
 
 /** Create a new Box object that stack its chidren horizontally. */
-fun HorizontalBox() : Box = uiNewHorizontalBox() ?: throw Error()
+fun HorizontalBox(block: Box.() -> Unit = {}) : Box = uiNewHorizontalBox()?.apply(block) ?: throw Error()
 
 /** Create a new Box object that stack its chidren vertically. */
-fun VerticalBox() : Box = uiNewVerticalBox() ?: throw Error()
+fun VerticalBox(block: Box.() -> Unit = {}) : Box = uiNewVerticalBox()?.apply(block) ?: throw Error()
 
 /** Destroy and free the Box. */
 fun Box.destroy() = uiControlDestroy(reinterpret())
@@ -527,7 +527,8 @@ internal fun _onEntry(widget: Entry?, ref: COpaquePointer?) {
 typealias MultilineEntry = CPointer<uiMultilineEntry>
 
 /** Create a new MultilineEntry. */
-fun MultilineEntry() : MultilineEntry = uiNewMultilineEntry() ?: throw Error()
+fun MultilineEntry(block: MultilineEntry.() -> Unit = {}) : MultilineEntry =
+        uiNewMultilineEntry()?.apply(block) ?: throw Error()
 
 /** Create a new non wrapping MultilineEntry. */
 fun NonWrappingMultilineEntry() : MultilineEntry = uiNewNonWrappingMultilineEntry() ?: throw Error()
@@ -1038,7 +1039,7 @@ var ProgressBar.value: Int
 typealias Button = CPointer<uiButton>
 
 /** Create a new Button. */
-fun Button(text: String) : Button = uiNewButton(text) ?: throw Error()
+fun Button(text: String, block: Button.() -> Unit = {}) : Button = uiNewButton(text)?.apply(block) ?: throw Error()
 
 /** Destroy and free the Button. */
 fun Button.destroy() = uiControlDestroy(reinterpret())


### PR DESCRIPTION
This PR adds a lambda to some widgets to avoid using the `apply` scope function to setup the instance created. It also has a default value so those who want to use `apply` anyway can do without problems.

**Before**
```kotlin
val button = Button(text = "Click").apply {
    action {
        println("Hello World")
    }
}
```

**After**
```kotlin
val button = Button(text = "Click") {
    action {
        println("Hello World")
    }
}
```