### PR TITLE
Add bindings to set font without using font button and updated drawte…

### DIFF
--- a/libui/src/nativeMain/kotlin/draw/text.kt
+++ b/libui/src/nativeMain/kotlin/draw/text.kt
@@ -54,9 +54,23 @@ class TextLayout(
 ///////////////////////////////////////////////////////////////////////////////
 
 /** Provides a complete description of a font where one is needed.  */
-class Font : Disposable<uiFontDescriptor>(
+class Font() : Disposable<uiFontDescriptor>(
     alloc = nativeHeap.alloc<uiFontDescriptor>().ptr
 ) {
+    constructor(family: String,
+                size: Double,
+                weight: uiTextWeight,
+                italic: uiTextItalic,
+                stretch: uiTextStretch) : this() {
+        with(ptr.pointed){
+            Family = uiAttributeFamily(uiNewFamilyAttribute(family))
+            Size = size
+            Weight = weight
+            Italic = italic
+            Stretch = stretch
+        }
+    }
+
     override fun clear() {
         if (ptr.pointed.Family != null) uiFreeFontButtonFont(ptr)
     }

--- a/samples/drawtext/src/nativeMain/kotlin/main.kt
+++ b/samples/drawtext/src/nativeMain/kotlin/main.kt
@@ -66,12 +66,14 @@ fun main(args: Array<String>) = appWindow(
     height = 480
 ) {
     hbox {
-        lateinit var font: FontButton
+        lateinit var fontButton: FontButton
         lateinit var align: Combobox
         lateinit var area: DrawArea
+        lateinit var checkbox: Checkbox
+        val georgia = Font("Georgia", 12.0, uiTextWeightNormal, uiTextItalicNormal, uiTextStretchNormal)
 
         vbox {
-            font = fontbutton {
+            fontButton = fontbutton {
                 action { area.redraw() }
             }
             form {
@@ -84,11 +86,19 @@ fun main(args: Array<String>) = appWindow(
                     action { area.redraw() }
                 }
             }
+            checkbox = checkbox("Use Georgia instead of button") {
+                action {
+                    fontButton.enabled = !this.value
+                    area.redraw()
+                }
+            }
         }
         area = drawarea {
             val str = makeAttributedString()
             draw {
-                text(str, font.value, it.AreaWidth, align.value.convert(), 0.0, 0.0)
+                val font = if (checkbox.value) georgia else fontButton.value
+
+                text(str, font, it.AreaWidth, align.value.convert(), 0.0, 0.0)
             }
             stretchy = true
         }


### PR DESCRIPTION
…xt sample to demonstrate usage.

This might not be necessary but I could not find a way in kotlin-libui to specify a font other than using a fontButton as I couldn't find kotlin bindings to the uiFontDescriptor struct that allowed setting: 
```
char *Family;
double Size;
uiTextWeight Weight;
uiTextItalic Italic;
uiTextStretch Stretch;
```

I created a binding to allow creating a font that specifies those properties however this is my first time using kotlin native and I am receiving an error upon close of the sample due to leaked data as shown below:
```
** (drawtext.kexe:9779): CRITICAL **: 13:48:33.189: [libui] /home/travis/build/msink/libui/unix/alloc.c:42:uiprivUninitAlloc() You have a bug: Some data was leaked; either you left a uiControl lying around or there's a bug in libui itself. Leaked data:
0x105fb20 uiAttribute
0x105fb80 char[] (uiAttribute)
```

Any assistance in how to better define the bindings for uiFontDescriptor or fixing the memory leak would be appreciated.