### PR TITLE
Update the kotlin libraries version

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -11,7 +11,7 @@ object Publish {
 }
 
 object Kotlin {
-    const val version = "1.3.70-eap-42"
+    const val version = "1.3.71-release-385"
 }
 
 object Libui {


### PR DESCRIPTION
This fix the master build problem, as the version "1.3.70-eap-42" is not available anymore in the bintray repository. The "1.3.71-release-385" is the latest one from 1.3 versions.